### PR TITLE
Change Softmax to LogSoftmax to use NLLLoss.

### DIFF
--- a/network.py
+++ b/network.py
@@ -114,8 +114,8 @@ class _netD(nn.Module):
         self.fc_dis = nn.Linear(13*13*512, 1)
         # aux-classifier fc
         self.fc_aux = nn.Linear(13*13*512, num_classes)
-        # softmax and sigmoid
-        self.softmax = nn.Softmax()
+        # log_softmax and sigmoid (change to LogSoftmax for NLLLoss)
+        self.log_softmax = nn.LogSoftmax(dim=1)
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, input):
@@ -139,7 +139,7 @@ class _netD(nn.Module):
             flat6 = conv6.view(-1, 13*13*512)
             fc_dis = self.fc_dis(flat6)
             fc_aux = self.fc_aux(flat6)
-        classes = self.softmax(fc_aux)
+        classes = self.log_softmax(fc_aux)
         realfake = self.sigmoid(fc_dis).view(-1, 1).squeeze(1)
         return realfake, classes
 
@@ -248,8 +248,8 @@ class _netD_CIFAR10(nn.Module):
         self.fc_dis = nn.Linear(4*4*512, 1)
         # aux-classifier fc
         self.fc_aux = nn.Linear(4*4*512, num_classes)
-        # softmax and sigmoid
-        self.softmax = nn.Softmax()
+        # log_softmax and sigmoid (change to LogSoftmax for NLLLoss)
+        self.log_softmax = nn.LogSoftmax(dim=1)
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, input):
@@ -273,6 +273,6 @@ class _netD_CIFAR10(nn.Module):
             flat6 = conv6.view(-1, 4*4*512)
             fc_dis = self.fc_dis(flat6)
             fc_aux = self.fc_aux(flat6)
-        classes = self.softmax(fc_aux)
+        classes = self.log_softmax(fc_aux)
         realfake = self.sigmoid(fc_dis).view(-1, 1).squeeze(1)
         return realfake, classes


### PR DESCRIPTION
Fix #3.

From [here](http://pytorch.org/docs/master/nn.html#torch.nn.Softmax), it is `LogSoftmax` should be used for `NLLLoss`, instead of `Softmax`.

> This module doesn’t work directly with NLLLoss, which expects the Log to be computed between the Softmax and itself. Use LogSoftmax instead (it’s faster and has better numerical properties).